### PR TITLE
Update mkrwan_03_gps_tracker.ino

### DIFF
--- a/mkrwan_03_gps_tracker/mkrwan_03_gps_tracker.ino
+++ b/mkrwan_03_gps_tracker/mkrwan_03_gps_tracker.ino
@@ -151,7 +151,7 @@ void buildPacket() {
   txBuffer[6] = ( altitudeGps >> 8 ) & 0xFF;
   txBuffer[7] = altitudeGps & 0xFF;
 
-  hdopGps = gps.hdop.value()/10;
+  hdopGps = gps.hdop.value()*10;
   txBuffer[8] = hdopGps & 0xFF;
 }
 


### PR DESCRIPTION
In my opinion the HDOP value must be multiplied by 10 and not divided to preserve the first decimal place. 
To restore the original value the division by will den be done on payload decoder side.
Otherwise you allways get a zero value on TTN-Mapper